### PR TITLE
Refactor compositor interface

### DIFF
--- a/src/compositors/niri.rs
+++ b/src/compositors/niri.rs
@@ -1,7 +1,5 @@
-use std::sync::{mpsc::Sender, Arc};
 
-use super::{CompositorInterface, WorkspaceVisible};
-use mio::Waker;
+use super::{CompositorInterface, WorkspaceVisible, EventSender};
 use niri_ipc::{socket::Socket, Event, Request, Response};
 
 pub struct NiriConnectionTask {}
@@ -29,7 +27,7 @@ impl NiriConnectionTask {
     }
 }
 impl CompositorInterface for NiriConnectionTask {
-    fn request_visible_workspaces(&mut self) -> Vec<WorkspaceVisible>{
+    fn request_visible_workspaces(&mut self) -> Vec<WorkspaceVisible> {
         if let Ok((Ok(Response::Workspaces(workspaces)), _)) = Socket::connect()
             .expect("failed to connect to niri socket")
             .send(Request::Workspaces)
@@ -37,20 +35,17 @@ impl CompositorInterface for NiriConnectionTask {
             return workspaces
                 .into_iter()
                 .filter(|w| w.is_active)
-                .map(|workspace| {
-                    WorkspaceVisible {
-                        output: workspace.output.unwrap_or_else(String::new),
-                        workspace_name: workspace.name.unwrap_or_else(String::new),
-                    }
+                .map(|workspace| WorkspaceVisible {
+                    output: workspace.output.unwrap_or_else(String::new),
+                    workspace_name: workspace.name.unwrap_or_else(String::new),
                 })
-            .collect()
-        } else
-        {
+                .collect();
+        } else {
             panic!("unable to retrieve niri workspaces")
         }
     }
 
-    fn subscribe_event_loop(self, tx: Sender<WorkspaceVisible>, waker: Arc<Waker>) {
+    fn subscribe_event_loop(self, event_sender: EventSender) {
         if let Ok((Ok(Response::Handled), mut callback)) = Socket::connect()
             .expect("failed to connect to niri socket")
             .send(Request::EventStream)
@@ -58,14 +53,10 @@ impl CompositorInterface for NiriConnectionTask {
             while let Ok(event) = callback() {
                 if let Event::WorkspaceActivated { id, focused: _ } = event {
                     let (workspace_name, output) = self.query_workspace(id);
-
-                    tx.send(WorkspaceVisible {
+                    event_sender.send(WorkspaceVisible {
                         output,
                         workspace_name,
-                    })
-                    .unwrap();
-
-                    waker.wake().unwrap();
+                    });
                 }
             }
         } else {

--- a/src/compositors/sway.rs
+++ b/src/compositors/sway.rs
@@ -1,7 +1,4 @@
-use std::sync::{mpsc::Sender, Arc};
-
-use super::{CompositorInterface, WorkspaceVisible};
-use mio::Waker;
+use super::{CompositorInterface, WorkspaceVisible, EventSender};
 use swayipc::{Connection, Event, EventType, WorkspaceChange};
 
 pub struct SwayConnectionTask {
@@ -30,7 +27,7 @@ impl CompositorInterface for SwayConnectionTask {
             .collect()
     }
 
-    fn subscribe_event_loop(self, tx: Sender<WorkspaceVisible>, waker: Arc<Waker>) {
+    fn subscribe_event_loop(self, event_sender: EventSender) {
         let event_stream = self.sway_conn.subscribe([EventType::Workspace]).unwrap();
         for event_result in event_stream {
             let event = event_result.unwrap();
@@ -39,14 +36,10 @@ impl CompositorInterface for SwayConnectionTask {
             };
             if let WorkspaceChange::Focus = workspace_event.change {
                 let current_workspace = workspace_event.current.unwrap();
-
-                tx.send(WorkspaceVisible {
+                event_sender.send(WorkspaceVisible {
                     output: current_workspace.output.unwrap(),
                     workspace_name: current_workspace.name.unwrap(),
-                })
-                .unwrap();
-
-                waker.wake().unwrap();
+                });
             }
         }
     }

--- a/src/compositors/sway.rs
+++ b/src/compositors/sway.rs
@@ -1,6 +1,4 @@
-use std::{
-    sync::{mpsc::Sender, Arc},
-};
+use std::sync::{mpsc::Sender, Arc};
 
 use super::{CompositorInterface, WorkspaceVisible};
 use mio::Waker;
@@ -19,47 +17,17 @@ impl SwayConnectionTask {
 }
 
 impl CompositorInterface for SwayConnectionTask {
-    fn request_visible_workspace(
-        &mut self,
-        output: &str,
-        tx: Sender<WorkspaceVisible>,
-        waker: Arc<Waker>,
-    ) {
-        if let Some(workspace) = self
-            .sway_conn
+    fn request_visible_workspaces(&mut self) -> Vec<WorkspaceVisible> {
+        self.sway_conn
             .get_workspaces()
             .unwrap()
             .into_iter()
             .filter(|w| w.visible)
-            .find(|w| w.output == output)
-        {
-            tx
-                .send(WorkspaceVisible {
-                    output: workspace.output,
-                    workspace_name: workspace.name,
-                })
-                .unwrap();
-
-            waker.wake().unwrap();
-        }
-    }
-
-    fn request_visible_workspaces(&mut self, tx: Sender<WorkspaceVisible>, waker: Arc<Waker>) {
-        for workspace in self
-            .sway_conn
-            .get_workspaces()
-            .unwrap()
-            .into_iter()
-            .filter(|w| w.visible)
-        {
-            tx
-                .send(WorkspaceVisible {
-                    output: workspace.output,
-                    workspace_name: workspace.name,
-                })
-                .unwrap();
-        }
-        waker.wake().unwrap();
+            .map(|workspace| WorkspaceVisible {
+                output: workspace.output,
+                workspace_name: workspace.name,
+            })
+            .collect()
     }
 
     fn subscribe_event_loop(self, tx: Sender<WorkspaceVisible>, waker: Arc<Waker>) {
@@ -72,12 +40,11 @@ impl CompositorInterface for SwayConnectionTask {
             if let WorkspaceChange::Focus = workspace_event.change {
                 let current_workspace = workspace_event.current.unwrap();
 
-                tx
-                    .send(WorkspaceVisible {
-                        output: current_workspace.output.unwrap(),
-                        workspace_name: current_workspace.name.unwrap(),
-                    })
-                    .unwrap();
+                tx.send(WorkspaceVisible {
+                    output: current_workspace.output.unwrap(),
+                    workspace_name: current_workspace.name.unwrap(),
+                })
+                .unwrap();
 
                 waker.wake().unwrap();
             }


### PR DESCRIPTION
I was unhappy with the CompositorInterface from my last PR - leaking all those details about how the information get's back into multibg was fine when it was only one compositor, but now it's multiple, I feel those concerns should be pulled up one level into the ConnectionTask struct.