### PR TITLE
allow specifying wallpaper by workspace number/index

### DIFF
--- a/src/compositors.rs
+++ b/src/compositors.rs
@@ -187,6 +187,7 @@ impl ConnectionTask {
                 .send(WorkspaceVisible {
                     output: workspace.output,
                     workspace_name: workspace.workspace_name,
+                    workspace_number: workspace.workspace_number,
                 })
                 .unwrap();
 
@@ -202,6 +203,7 @@ impl ConnectionTask {
                 .send(WorkspaceVisible {
                     output: workspace.output,
                     workspace_name: workspace.workspace_name,
+                    workspace_number: workspace.workspace_number
                 })
                 .unwrap();
 
@@ -214,6 +216,7 @@ impl ConnectionTask {
 pub struct WorkspaceVisible {
     pub output: String,
     pub workspace_name: String,
+    pub workspace_number: i32,
 }
 
 #[derive(Deserialize)]

--- a/src/compositors/hyprland.rs
+++ b/src/compositors/hyprland.rs
@@ -70,6 +70,7 @@ impl CompositorInterface for HyprlandConnectionTask {
                         output: active_monitor.clone(),
                         workspace_name: String::from_utf8(event_data.to_vec())
                             .unwrap(),
+                        workspace_number: -1,
                     });
                 } else if event_name == b"focusedmon" {
                     let comma_pos = event_data.iter()
@@ -135,6 +136,7 @@ fn current_state() -> CurrentState {
         visible_workspaces.push(WorkspaceVisible {
             output: monitor.name,
             workspace_name: monitor.active_workspace.name,
+            workspace_number: -1,
         });
     }
     CurrentState { active_monitor, visible_workspaces }

--- a/src/compositors/niri2502.rs
+++ b/src/compositors/niri2502.rs
@@ -21,6 +21,7 @@ impl CompositorInterface for NiriConnectionTask {
                 output: workspace.output.unwrap_or_default(),
                 workspace_name: workspace.name
                     .unwrap_or_else(|| format!("{}", workspace.idx)),
+                workspace_number: workspace.idx.into(),
             })
             .collect()
     }
@@ -52,8 +53,9 @@ fn find_workspace(workspaces: &[Workspace], id: u64) -> WorkspaceVisible {
         .unwrap_or_else(|| panic!("Unknown niri workspace id {id}"));
     let workspace_name = workspace.name.clone()
         .unwrap_or_else(|| format!("{}", workspace.idx));
+    let workspace_number: i32 = workspace.idx.into();
     let output = workspace.output.clone().unwrap_or_default();
-    WorkspaceVisible { output, workspace_name }
+    WorkspaceVisible { output, workspace_name, workspace_number }
 }
 
 fn request_event_stream() -> impl FnMut() -> Result<Event, io::Error> {

--- a/src/compositors/niri2505.rs
+++ b/src/compositors/niri2505.rs
@@ -21,6 +21,7 @@ impl CompositorInterface for NiriConnectionTask {
                 output: workspace.output.unwrap_or_default(),
                 workspace_name: workspace.name
                     .unwrap_or_else(|| format!("{}", workspace.idx)),
+                workspace_number: workspace.idx.into(),
             })
             .collect()
     }
@@ -52,8 +53,9 @@ fn find_workspace(workspaces: &[Workspace], id: u64) -> WorkspaceVisible {
         .unwrap_or_else(|| panic!("Unknown niri workspace id {id}"));
     let workspace_name = workspace.name.clone()
         .unwrap_or_else(|| format!("{}", workspace.idx));
+    let workspace_number: i32 = workspace.idx.into();
     let output = workspace.output.clone().unwrap_or_default();
-    WorkspaceVisible { output, workspace_name }
+    WorkspaceVisible { output, workspace_name, workspace_number }
 }
 
 fn request_event_stream() -> impl FnMut() -> Result<Event, io::Error> {

--- a/src/compositors/sway.rs
+++ b/src/compositors/sway.rs
@@ -25,6 +25,7 @@ impl CompositorInterface for SwayConnectionTask {
             .map(|workspace| WorkspaceVisible {
                 output: workspace.output,
                 workspace_name: workspace.name,
+                workspace_number: workspace.num,
             })
             .collect()
     }
@@ -42,6 +43,7 @@ impl CompositorInterface for SwayConnectionTask {
                 event_sender.send(WorkspaceVisible {
                     output: current_workspace.output.unwrap(),
                     workspace_name: current_workspace.name.unwrap(),
+                    workspace_number: current_workspace.num.unwrap(),
                 });
             }
         }

--- a/src/image.rs
+++ b/src/image.rs
@@ -25,6 +25,7 @@ pub enum ColorTransform {
 pub struct WallpaperFile {
     pub path: PathBuf,
     pub workspace: String,
+    pub workspace_number: i32,
     pub canon_path: PathBuf,
     pub canon_modified: u128,
 }
@@ -49,6 +50,7 @@ pub fn output_wallpaper_files(
         }
         let workspace = path.file_stem().unwrap()
             .to_string_lossy().into_owned();
+        let workspace_number: i32 = workspace.parse().unwrap_or_default();
         let canon_path = match path.canonicalize() {
             Ok(canon_path) => canon_path,
             Err(e) => {
@@ -66,7 +68,7 @@ pub fn output_wallpaper_files(
         let canon_modified = canon_metadata.modified().unwrap()
             .duration_since(UNIX_EPOCH).unwrap()
             .as_nanos();
-        ret.push(WallpaperFile { path, workspace, canon_path, canon_modified });
+        ret.push(WallpaperFile { path, workspace, workspace_number, canon_path, canon_modified });
     }
     Ok(ret)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -290,7 +290,7 @@ fn handle_sway_event(
         if let Some(affected_bg_layer) = state.background_layers.iter_mut()
             .find(|bg_layer| bg_layer.output_name == workspace.output)
         {
-            affected_bg_layer.draw_workspace_bg(&workspace.workspace_name);
+            affected_bg_layer.draw_workspace_bg(&workspace.workspace_name, workspace.workspace_number);
         } else {
             error!(
                 "Workspace '{}' is on an unknown output '{}', \


### PR DESCRIPTION
I specify my wallpapers based on the numbering of my workspaces, and wished to preserve the ability to dynamically name my workspaces without having to manage excessive symlinks or breaking workspace ordering. The changes in this PR satisfy my uses, and seem to me like a generally useful feature.

Before using the _default.jpg fallback wallpaper, check if any wallpaper file exists matching the workspace's number/index. If a wallpaper file exists matching the workspace's name, it is still used first.

The Sway implementation has been tested, the Niri implementation has not been tested. The Hyprland implementation is incomplete as I'm unfamiliar with how its workspace data is being parsed. For now, it just uses a dummy value of `0` for every workspace number. The stubs are in place so if someone else is able and would like to, it should only require updating `workspace_number: 0` on lines 73 and 139 of [hyprland.rs](https://github.com/pogmommy/multibg-wayland/blob/308769f65ad7ebd294414821e89279bb9673dc0f/src/compositors/hyprland.rs#L73).

Happy to hear your thoughts and make changes if this feature would be welcome in its current/a modified form. I considered implementing a cli flag (`--index`/`--no-index`?) to explicitly enable/disable the behavior this PR introduces, in case it's anticipated to interfere with existing uses.